### PR TITLE
added id property and custom_execute method

### DIFF
--- a/ooop.py
+++ b/ooop.py
@@ -587,6 +587,10 @@ class Data(object):
             self.INSTANCES.pop(key)
             self.INSTANCES['%s:%s' % (instance._model, instance._ref)] = instance
         self.save()
+    
+    @property
+    def id(self):
+        return self._ref
 
     def __repr__(self):
         """ default representation: <model:id> """


### PR DESCRIPTION
Hi,
only now I see that ecarreras has added these improvements too :(

anyway... I think the id should defined as a property (like I did).

for the custom_execute which allows to execute custom objects method, well... let's choose one of them...
ecarreras called it simply "execute" which maybe is better. I tried to be as "verbose" as possible calling it "custom_execute". 
